### PR TITLE
Parentage Pedigree Field

### DIFF
--- a/includes/TripalFields/co_010__parentage_of_pedigree/co_010__parentage_of_pedigree.inc
+++ b/includes/TripalFields/co_010__parentage_of_pedigree/co_010__parentage_of_pedigree.inc
@@ -1,0 +1,209 @@
+<?php
+/**
+ * @class
+ * Purpose: Provide quick browse functionality for entity pages
+ *
+ * Data: No data.
+ * Assumptions:
+ */
+class co_010__parentage_of_pedigree extends TripalField {
+  // --------------------------------------------------------------------------
+  //                     EDITABLE STATIC CONSTANTS
+  //
+  // The following constants SHOULD be set for each descendant class.  They are
+  // used by the static functions to provide information to Drupal about
+  // the field and it's default widget and formatter.
+  // --------------------------------------------------------------------------
+  // The default label for this field.
+  public static $default_label = 'Parental Pedigree';
+  // The default description for this field.
+  public static $default_description = 'A tree diagram of parental pedigree';
+  // The default widget for this field.
+  public static $default_widget = 'co_010__parentage_of_pedigree_widget';
+  // The default formatter for this field.
+  public static $default_formatter = 'co_010__parentage_of_pedigree_formatter';
+  // The module that manages this field.
+  public static $module = 'trpfancy_fields';
+
+  // A list of global settings. These can be accessed within the
+  // globalSettingsForm.  When the globalSettingsForm is submitted then
+  // Drupal will automatically change these settings for all fields.
+  // Once instances exist for a field type then these settings cannot be
+  // changed.
+  public static $default_settings = array(
+    'storage' => 'tripal_no_storage',
+    // It is expected that all fields set a 'value' in the load() function.
+    // In many cases, the value may be an associative array of key/value pairs.
+    // In order for Tripal to provide context for all data, the keys should
+    // be a controlled vocabulary term (e.g. rdfs:type). Keys in the load()
+    // function that are supported by the query() function should be
+    // listed here.
+    'browseable_keys' => array(),
+  );
+
+  // Provide a list of instance specific settings. These can be access within
+  // the instanceSettingsForm.  When the instanceSettingsForm is submitted
+  // then Drupal with automatically change these settings for the instance.
+  // It is recommended to put settings at the instance level whenever possible.
+  // If you override this variable in a child class be sure to replicate the
+  // term_name, term_vocab, term_accession and term_fixed keys as these are
+  // required for all TripalFields.
+  public static $default_instance_settings = array(
+    // The short name for the vocabulary (e.g. schema, SO, GO, PATO, etc.).
+    'term_vocabulary' => 'CO_010',
+    // The name of the term.
+    'term_name' => 'parentage of pedigree',
+    // The unique ID (i.e. accession) of the term.
+    'term_accession' => '0000220',
+    // Set to TRUE if the site admin is not allowed to change the term
+    // type, otherwise the admin can change the term mapped to a field.
+    'term_fixed' => FALSE,
+    // Indicates if this field should be automatically attached to display
+    // or web services or if this field should be loaded separately. This
+    // is convenient for speed.  Fields that are slow should for loading
+    // should have auto_attach set to FALSE so tha their values can be
+    // attached asynchronously.
+    'auto_attach' => FALSE,
+    // The table where the options for this specific field are stored.
+    // This can be one of trpfancy_browse_options or trpfancy_browse_options_per_entity
+    // based on admin configuration. Default: trpfancy_browse_options.
+    'option_storage' => '',
+    // A list of browser types this field intends to provide.
+    'browser_types' => '',
+  );
+
+  // A boolean specifying that users should not be allowed to create
+  // fields and instances of this field type through the UI. Such
+  // fields can only be created programmatically with field_create_field()
+  // and field_create_instance().
+  public static $no_ui = FALSE;
+  // A boolean specifying that the field will not contain any data. This
+  // should exclude the field from web services or downloads.  An example
+  // could be a quick browse field that appears on the page that redirects
+  // the user but otherwise provides no data.
+  public static $no_data = TRUE;
+
+ /**
+   * Loads the field values from the underlying data store.
+   *
+   * @param $entity
+   *
+   * @return
+   *   An array of the following format:
+   *     $entity->{$field_name}['und'][0]['value'] = $value;
+   *   where:
+   *     - $entity is the entity object to which this field is attached.
+   *     - $field_name is the name of this field
+   *     - 'und' is the language code (in this case 'und' == undefined)
+   *     - 0 is the cardinality.  Increment by 1 when more than one item is
+   *       available.
+   *     - 'value' is the key indicating the value of this field. It should
+   *       always be set.  The value of the 'value' key will be the contents
+   *       used for web services and for downloadable content.  The value
+   *       should be of the follow format types: 1) A single value (text,
+   *       numeric, etc.) 2) An array of key value pair. 3) If multiple entries
+   *       then cardinality should incremented and format types 1 and 2 should
+   *       be used for each item.
+   *   The array may contain as many other keys at the same level as 'value'
+   *   but those keys are for internal field use and are not considered the
+   *   value of the field.
+   *
+   *
+   */
+  public function load($entity) {
+    // The record.
+    $chado_record_id = $entity->chado_record_id;
+
+    // We need the field name to ensure we save the data in the correct field!
+    $field_name = $this->instance['field_name'];
+
+    // Set this property for formatteer to render.
+    $entity->{$field_name}['und'][0]['value']['GCP germplasm ontology:parentage of pedigree'] = '';
+
+
+    // Chart configuration:
+    $chart = array(
+      // Whether to put figure key legend or not.
+      // TRUE of FALSE;
+      'draw_key_legend' => TRUE,
+      // Where to put figure key legend.
+      // left, right or top
+      'key_legend_position' => 'top',
+      // On page load, default number of level to collapse.
+      // From end leaf down to root.
+      'collapse_level' => 3,
+
+      // Element #ids. Any future requirements to add element
+      // can be inserted into this parent container.
+      'wrapper' => 'tripald3-pedigree-wrapper',
+      // Append svg to.
+      'element' => 'tripald3-pedigree'
+    );
+
+
+    // Data:
+    $data = array(
+      'name' => $entity->title,
+    );
+
+
+    // Source:
+    $path_base     = $GLOBALS['base_url'];
+    $path_to_module = drupal_get_path('module', 'trpfancy_fields');
+    $path_to_tfield  = $path_base . '/' . $path_to_module . '/includes/TripalFields';
+    $path_to_pedigree = $path_to_tfield . '/' . get_class($this);
+    $path_to_JSON      = $path_base . '/ajax/tripal/d3-json/relationships/stock/' . $chado_record_id;
+
+    // Germplasm type.
+    $stock_type = $entity->chado_record->type_id->name;
+    $path_to_germpage   = $path_base . '/' . strtolower($stock_type) . '/';
+
+    $source = array(
+      'path_JSON' => $path_to_JSON,
+      'path_T3field' => $path_to_pedigree,
+      'path_germpage'  => $path_to_germpage,
+    );
+
+
+
+    $entity->{$field_name}['und'][0]['vars'] = array(
+      'chart'  => $chart,
+      'data'   => $data,
+      'source' => $source,
+    );
+  }
+
+  /**
+   * Provides a form for the 'Field Settings' of an instance of this field.
+   *
+   * This function corresponds to the hook_field_instance_settings_form()
+   * function of the Drupal Field API.
+   *
+   * Validation of the instance settings form is not supported by Drupal, but
+   * the TripalField class does provide a mechanism for supporting validation.
+   * To allow for validation of your setting form you must call the parent
+   * in your child class:
+   *
+   * @code
+   *   $element = parent::instanceSettingsForm();
+   * @endcode
+   *
+   * Please note, the form generated with this function does not easily
+   * support AJAX calls in the same way that other Drupal forms do.  If you
+   * need to use AJAX you must manually alter the $form in your ajax call.
+   * The typical way to handle updating the form via an AJAX call is to make
+   * the changes in the form function itself but that doesn't work here.
+   */
+  public function instanceSettingsForm() {
+
+    // Retrieve the current settings.
+    // If this field was just created these will contain the default values.
+    $settings = $this->instance['settings'];
+
+    // Allow the parent Tripal Field to set up the form element for us.
+    $element = parent::instanceSettingsForm();
+
+    return $element;
+  }
+}
+

--- a/includes/TripalFields/co_010__parentage_of_pedigree/co_010__parentage_of_pedigree_formatter.inc
+++ b/includes/TripalFields/co_010__parentage_of_pedigree/co_010__parentage_of_pedigree_formatter.inc
@@ -1,0 +1,90 @@
+<?php
+/**
+ * @class
+ * Purpose: Provide a quick search on entity pages which submits/redirects to a full search.
+ *
+ * Display: A simple textfield search form.
+ * Configuration:
+ *   - path to the full search.
+ *   - the URL token (query parameter) the value applies to.
+ *   - help text.
+ *   - textfield placeholder.
+ *   - search button text.
+ *   - autocomplete path.
+ */
+class co_010__parentage_of_pedigree_formatter extends TripalFieldFormatter {
+  // The default label for this field.
+  public static $default_label = 'Parental Pedigree';
+
+  // The list of field types for which this formatter is appropriate.
+  public static $field_types = array('co_010__parentage_of_pedigree');
+
+  /**
+   *  Provides the display for a field
+   *
+   * This function corresponds to the hook_field_formatter_view()
+   * function of the Drupal Field API.
+   *
+   *  This function provides the display for a field when it is viewed on
+   *  the web page.  The content returned by the formatter should only include
+   *  what is present in the $items[$delta]['values] array. This way, the
+   *  contents that are displayed on the page, via webservices and downloaded
+   *  into a CSV file will always be identical.  The view need not show all
+   *  of the data in the 'values' array.
+   *
+   *  @param $element
+   *  @param $entity_type
+   *  @param $entity
+   *  @param $langcode
+   *  @param $items
+   *  @param $display
+   *
+   *  @return
+   *    An element array compatible with that returned by the
+   *    hook_field_formatter_view() function.
+   */
+  public function view(&$element, $entity_type, $entity, $langcode, $items, $display) {
+    // Grab the name of the field to create a unique ID for the chart.
+    $field_name = $this->instance['field_name'];
+    $display_vars = $entity->{$field_name}['und'][0]['vars'];
+
+    // Prepare settings:
+    drupal_add_js(array('trpfancyFields' => array(
+      // Stock name.
+      'name'   => $display_vars['data']['name'],
+      // JSON url.
+      'url'    => $display_vars['source'],
+      // Append SVG element and configurations.
+      'chart'  => $display_vars['chart']),
+
+    ), 'setting');
+
+
+    // Initialize chart:
+    // Load Tripal D3 API.
+    tripald3_load_libraries();
+
+    drupal_add_js($display_vars['source']['path_T3field'] . '/theme/script.js',
+      array(
+        // An external file scrip.js in theme/
+        'type' => 'file',
+        // At foot of DOM to ensure document is ready for width estimate.
+        'scope' => 'footer'
+      )
+    );
+
+
+    // Add element:
+    $element[0] = array(
+      '#type' => 'markup',
+      '#markup' => '
+        <div id="' . $display_vars['chart']['wrapper']  . '">
+          <div id="tripald3-pedigree-wait">Loading pedigree tree diagram. Please wait...</div>
+          <div id="' . $display_vars['chart']['element'] . '"></div>
+        </div>',
+    );
+
+
+    return $element;
+  }
+}

--- a/includes/TripalFields/co_010__parentage_of_pedigree/co_010__parentage_of_pedigree_widget.inc
+++ b/includes/TripalFields/co_010__parentage_of_pedigree/co_010__parentage_of_pedigree_widget.inc
@@ -1,0 +1,126 @@
+<?php
+/**
+ * @class
+ * Purpose: Provide a graphical summary of data stored in a materialized view.
+ *   This is a generic, configurable fields to make it easier to add charts
+ *   to Tripal Content pages.
+ *
+ * Allowing edit? No
+ */
+class co_010__parentage_of_pedigree_widget extends TripalFieldWidget {
+
+  // The default lable for this field.
+  public static $default_label = 'No Edits';
+
+  // The list of field types for which this formatter is appropriate.
+  public static $field_types = array('co_010__parentage_of_pedigree');
+
+  /**
+   * Provides the form for editing of this field.
+   *
+   * This function corresponds to the hook_field_widget_form()
+   * function of the Drupal Field API.
+   *
+   * This form is diplayed when the user creates a new entity or edits an
+   * existing entity.  If the field is attached to the entity then the form
+   * provided by this function will be displayed.
+   *
+   * At a minimum, the form must have a 'value' element.  For Tripal, the
+   * 'value' element of a field always corresponds to the value that is
+   * presented to the end-user either directly on the page (with formatting)
+   * or via web services, or some other mechanism.  However, the 'value' is
+   * sometimes not enough for a field.  For example, the Tripal Chado module
+   * maps fields to table columns and sometimes those columns are foreign keys
+   * therefore, the Tripal Chado modules does not just use the 'value' but adds
+   * additional elements to help link records via FKs.  But even in this case
+   * the 'value' element must always be present in the return form and in such
+   * cases it's value should be set equal to that added in the 'load' function.
+   *
+   * @param $widget
+   * @param $form
+   *   The form structure where widgets are being attached to. This might be a
+   *   full form structure, or a sub-element of a larger form.
+   * @param $form_state
+   *   An associative array containing the current state of the form.
+   * @param $langcode
+   *   The language associated with $items.
+   * @param $items
+   *   Array of default values for this field.
+   * @param $delta
+   *   The order of this item in the array of subelements (0, 1, 2, etc).
+   * @param $element
+   * A form element array containing basic properties for the widget:
+   *  - #entity_type: The name of the entity the field is attached to.
+   *  - #bundle: The name of the field bundle the field is contained in.
+   *  - #field_name: The name of the field.
+   *  - #language: The language the field is being edited in.
+   *  - #field_parents: The 'parents' space for the field in the form. Most
+   *    widgets can simply overlook this property. This identifies the location
+   *    where the field values are placed within $form_state['values'], and is
+   *    used to access processing information for the field through the
+   *    field_form_get_state() and field_form_set_state() functions.
+   *  - #columns: A list of field storage columns of the field.
+   *  - #title: The sanitized element label for the field instance, ready for
+   *    output.
+   *  - #description: The sanitized element description for the field instance,
+   *    ready for output.
+   *  - #required: A Boolean indicating whether the element value is required;
+   *    for required multiple value fields, only the first widget's values are
+   *    required.
+   *  - #delta: The order of this item in the array of subelements; see
+   *    $delta above
+   */
+  public function form(&$widget, &$form, &$form_state, $langcode, $items, $delta, $element) {
+    parent::form($widget, $form, $form_state, $langcode, $items, $delta, $element);
+  }
+
+  /**
+   * Performs validation of the widgetForm.
+   *
+   * Use this validate to ensure that form values are entered correctly.
+   * The 'value' key of this field must be set in the $form_state['values']
+   * array anytime data is entered by the user.  It may be the case that there
+   * are other fields for helping select a value. In the end those helper
+   * fields must be used to set the 'value' field.
+   */
+  public function validate($element, $form, &$form_state, $langcode, $delta) {
+  }
+
+  /**
+   * Performs extra commands when the entity form is submitted.
+   *
+   * Drupal typically does not provide a submit hook for fields.  The
+   * TripalField provides one to allow for behind-the-scenes actions to
+   * occur.   This function should never be used for updates, deletes or
+   * inserts for the Chado table associated with the field.  Rather, the
+   * storage backend should be allowed to handle inserts, updates deletes.
+   * However, it is permissible to perform inserts, updates or deletions within
+   * Chado using this function.  Those operations can be performed if needed but
+   * on other tables not directly associated with the field.
+   *
+   * An example is the chado.feature_synonym table.  The chado_linker__synonym
+   * field allows the user to provide a brand new synonynm and it must add it
+   * to the chado.synonym table prior to the record in the
+   * chado.feature_synonym table.  This insert occurs in the widgetFormSubmit
+   * function.
+   *
+   *  @param $entity_type
+   *    The type of $entity.
+   *  @param $entity
+   *    The entity for the operation.
+   *  @param $field
+   *    The field structure for the operation.
+   *  @param $instance
+   *    The instance structure for $field on $entity's bundle.
+   *  @param $langcode
+   *    The language associated with $items.
+   *  @param $items
+   *    $entity->{$field['field_name']}[$langcode], or an empty array if unset.
+   *  @param $form
+   *    The submitted form array.
+   *  @param $form_state.
+   *    The form state array.
+   */
+  public function submit($form, &$form_state, $entity_type, $entity, $langcode, $delta) {
+  }
+}

--- a/includes/TripalFields/co_010__parentage_of_pedigree/theme/script.js
+++ b/includes/TripalFields/co_010__parentage_of_pedigree/theme/script.js
@@ -1,0 +1,78 @@
+/**
+ * @file
+ * Manage parentage pedigree behavior
+ */
+(function ($) {
+Drupal.behaviors.ParentagePedigree = {
+  attach: function(context, settings) {
+    var stockName =  Drupal.settings.trpfancyFields.name;
+    var url       =  Drupal.settings.trpfancyFields.url;
+    var pedigreeChart =  Drupal.settings.trpfancyFields.chart;
+
+    var maxDepth, width = 0;
+
+    $.getJSON(url.path_JSON, function(data) {
+
+      // Calculate the height of the diagram based on the depth of the tree.
+      // Assumption: distance between nodes is ~75px
+      getDepth = function (obj) {
+        var depth = 0;
+        if (obj.children) {
+          obj.children.forEach(function (d) {
+            var tmpDepth = getDepth(d)
+
+            if (tmpDepth > depth) {
+              depth = tmpDepth
+            }
+          })
+        }
+
+        return 1 + depth
+      }
+
+      maxDepth = getDepth(data[0]);
+
+      // Calculate the width of the diagram based on the overview pane.
+      // We need to do this b/c the hidden div that will contain the tree
+      // has width=0 at this point ;-P.
+
+      // Find the table (summary/overivew) in one of the tripal-panes not hidden.
+      // Set the <table> to occupy the entire pane and use the width as the
+      // estimated width of the SVG element.
+      $('.ds-right div:visible').find('table').css('width', '100%');
+      width = $('.ds-right div:visible').find('table').innerWidth();
+
+      if (width == 0) {
+        // All else fail, set to 750;
+        width = 750;
+        console.error('Unable to detect width thus defaulting to 750px.');
+      }
+
+      // The following code uses the Tripal D3 module to draw a pedigree tree
+      // and attach it to an #tree element. Furthermore, it specifies a path
+      // to get the data for the tree from.
+      tripalD3.drawFigure(data, {
+        'chartType'      : 'pedigree',
+        'elementId'      : pedigreeChart.element,
+        'height'         : 75 * maxDepth,
+        'width'          : width,
+        'chartOptions'   : {
+          'nodeLinks'    : function(d) { return d.current.url; },
+        },
+        'title'          : '<em>' + stockName + '</em> Parental Pedigree',
+        'legend'         : 'The above tree depicts the parentage of <em>' + stockName + '</em>. The type of relationship is indicated both using line styles defined in the legend and also in sentence form when you hover your mouse over the relationship lines. Additional information about each germplasm can be obtained by clicking on the Germplasm name. Furthermore, parts of the pedigree diagram can be collapsed or expanded by double-clicking on a Germplasm node.',
+
+        // Do not render the tree legend on the upper left hand corner
+        // since we want it on top.
+        'drawKey'        : pedigreeChart.draw_key_legend,
+        'keyPosition'    : pedigreeChart.key_legend_position,
+
+        // On load, collapse level from the end leaf down.
+        // Levels:
+        'collapsedDepth' : pedigreeChart.collapse_level,
+      });
+
+
+      $('#tripald3-pedigree-wait').remove();
+    });
+}}}(jQuery));

--- a/includes/TripalFields/co_010__parentage_of_pedigree/theme/script.js
+++ b/includes/TripalFields/co_010__parentage_of_pedigree/theme/script.js
@@ -56,9 +56,6 @@ Drupal.behaviors.ParentagePedigree = {
         'elementId'      : pedigreeChart.element,
         'height'         : 75 * maxDepth,
         'width'          : width,
-        'chartOptions'   : {
-          'nodeLinks'    : function(d) { return d.current.url; },
-        },
         'title'          : '<em>' + stockName + '</em> Parental Pedigree',
         'legend'         : 'The above tree depicts the parentage of <em>' + stockName + '</em>. The type of relationship is indicated both using line styles defined in the legend and also in sentence form when you hover your mouse over the relationship lines. Additional information about each germplasm can be obtained by clicking on the Germplasm name. Furthermore, parts of the pedigree diagram can be collapsed or expanded by double-clicking on a Germplasm node.',
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- No need to include the issue number in the title :-) -->

## Metadata
<!--- If it fixes an open issue, please add the issue link below. -->
 - Issue https://github.com/tripal/trpfancy_fields/issues/9

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I feel this PR is ready to be merged.
- [x] This PR is dependent upon 
https://github.com/tripal/tripald3/issues/4

Documentation:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

## Description
This PR will allow this module to generate parentage pedigree diagram.

## Testing?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how
      your change affects other areas of the code, etc. -->
<!--- Reviewers will use this section to test the submission! -->
- [x] I tested on a generic Tripal Site
- [x] I tested on a KnowPulse Clone
- [ ] This PR includes automated testing

To test this PR:
1. Ensure that cvterm required exists:
Term: parentage of pedigree
CV: GCP germplasm ontology
DB: CO_010
Accession: 0000220

2. Install or enable module.
3. In Structure/Tripal Content Types, create a new field for a selected content type and set the Field
Type to Parental Pedigree. Ensure to enable this field in Manage Display after saving the new field.
4. Load a Tripal Content where this field was enabled to view diagram.

Available Settings:
- Allow module to collapse a certain level of the tree by default.
- Position figure legend key on top, left or right of the tree.
- Toggle to show or hide figure legend key.
- Rename element id where chart elements are added.

Note: To test each option, a full clear cache action is required for it to take effect.

To test/modify these available options:
1. Load the field definition file (.inc) of parentage of pedigree field.
2. An associative array in load() method titled Chart configuration is defined as a value/key pair for each option.
3. Modify the value (supported values are indicated in inline comment for each option).
4. Clear cache and refresh page for new configuration to apply.

Things to keep an eye on:
1. When a leaf/node is hidden, expanding it would also expand the vertical height of the diagram. The same when collapsing but will reduce the height.
![expand collapse](https://user-images.githubusercontent.com/15472253/52893861-905dc380-3166-11e9-8ac3-e98f215f2db8.gif)

2. Depending on the available width, the figure legend key will resize to ensure elements will fit
in a given space.
![size](https://user-images.githubusercontent.com/15472253/52893922-5a6d0f00-3167-11e9-9713-4ce5a96ab677.gif)

3. Node will link to a void/top page when a node ppints to a Tripal 3 page that does not exist yet.
![no page](https://user-images.githubusercontent.com/15472253/52894030-e03d8a00-3168-11e9-83f9-7e8ff6767b7e.gif)

4. A note  underneath figure legend keys should also show number of level collapsed set.
![note](https://user-images.githubusercontent.com/15472253/52894098-00ba1400-316a-11e9-9a6e-d4a5f9dcbcfe.jpg)

