### PR TITLE
Auto uniquename

### DIFF
--- a/includes/TripalFields/data__identifier/data__identifier_widget.inc
+++ b/includes/TripalFields/data__identifier/data__identifier_widget.inc
@@ -108,27 +108,30 @@ class data__identifier_widget extends ChadoFieldWidget {
 
         // Pull system variable for configured prefix.
         $prefix = variable_get('trpfancy_field_identifier_prefix');
-        $unique_name = $prefix . ' + ID #';
-        $desciption = 'ID # will be set automatically on creation.';
 
-        // Use this to flag process that user is creating a new record
-        // and quick reference to the field.
-        $form['trpfancy_fields_field_name'] = array(
-          '#type' => 'value',
-          '#value' => $field_name,
-        );
+        if (isset($prefix) && !empty($prefix)) {
+          $unique_name = $prefix . ' + ID #';
+          $desciption = 'ID # will be set automatically on creation.';
 
-        $widget['table'] = array(
-          '#type' => 'value',
-          '#value' => $field_table,
-        );
+          // Use this to flag process that user is creating a new record
+          // and quick reference to the field.
+          $form['trpfancy_fields_field_name'] = array(
+            '#type' => 'value',
+            '#value' => $field_name,
+          );
 
-        $id = uniqid();
-        // What actually gets saved.
-        $widget['value'] = array(
-          '#type' => 'value',
-          '#value' => $id,
-        );
+          $widget['table'] = array(
+            '#type' => 'value',
+            '#value' => $field_table,
+          );
+
+          $id = uniqid();
+          // What actually gets saved.
+          $widget['value'] = array(
+            '#type' => 'value',
+            '#value' => $id,
+          );
+        }
       }
 
       // The value presented to the user via load.

--- a/includes/TripalFields/data__identifier/data__identifier_widget.inc
+++ b/includes/TripalFields/data__identifier/data__identifier_widget.inc
@@ -85,7 +85,9 @@ class data__identifier_widget extends ChadoFieldWidget {
 
       // When interface to set prefix:
       // Notice for admin where they can alter the prefix use to formulate uniquename.
-      // tripal_set_message('Administrators, you can set prefix used in uniquename field in [link here].', TRIPAL_INFO, array('return_html' => FALSE));
+      // @see hook_menu().
+      $link = l('Update Prefix', 'admin/tripal/extension/trpfancy_fields/prefix');
+      tripal_set_message('Administrators, you can set prefix used in uniquename field in ' . $link . '.', TRIPAL_INFO, array('return_html' => FALSE));
 
       // Dertermine if process is Create or Update. To test: check if chado_record_id
       // were set to an id number.
@@ -109,7 +111,8 @@ class data__identifier_widget extends ChadoFieldWidget {
         $unique_name = $prefix . ' + ID #';
         $desciption = 'ID # will be set automatically on creation.';
 
-        // Use this to flag process that user is creating a new record.
+        // Use this to flag process that user is creating a new record
+        // and quick reference to the field.
         $form['trpfancy_fields_field_name'] = array(
           '#type' => 'value',
           '#value' => $field_name,

--- a/includes/TripalFields/data__identifier/data__identifier_widget.inc
+++ b/includes/TripalFields/data__identifier/data__identifier_widget.inc
@@ -1,0 +1,253 @@
+<?php
+
+/**
+ * @class
+ * Purpose: Provide a graphical summary of data stored in a materialized view.
+ *   This is a generic, configurable fields to make it easier to add charts
+ *   to Tripal Content pages.
+ *
+ * Allowing edit? No
+ */
+class data__identifier_widget extends ChadoFieldWidget {
+
+  // The default lable for this field.
+  public static $default_label = 'Autocomplete Uniquename';
+
+  // The list of field types for which this formatter is appropriate.
+  public static $field_types = array('text');
+
+  /**
+   * Provides the form for editing of this field.
+   *
+   * This function corresponds to the hook_field_widget_form()
+   * function of the Drupal Field API.
+   *
+   * This form is diplayed when the user creates a new entity or edits an
+   * existing entity.  If the field is attached to the entity then the form
+   * provided by this function will be displayed.
+   *
+   * At a minimum, the form must have a 'value' element.  For Tripal, the
+   * 'value' element of a field always corresponds to the value that is
+   * presented to the end-user either directly on the page (with formatting)
+   * or via web services, or some other mechanism.  However, the 'value' is
+   * sometimes not enough for a field.  For example, the Tripal Chado module
+   * maps fields to table columns and sometimes those columns are foreign keys
+   * therefore, the Tripal Chado modules does not just use the 'value' but adds
+   * additional elements to help link records via FKs.  But even in this case
+   * the 'value' element must always be present in the return form and in such
+   * cases it's value should be set equal to that added in the 'load' function.
+   *
+   * @param $widget
+   * @param $form
+   *   The form structure where widgets are being attached to. This might be a
+   *   full form structure, or a sub-element of a larger form.
+   * @param $form_state
+   *   An associative array containing the current state of the form.
+   * @param $langcode
+   *   The language associated with $items.
+   * @param $items
+   *   Array of default values for this field.
+   * @param $delta
+   *   The order of this item in the array of subelements (0, 1, 2, etc).
+   * @param $element
+   * A form element array containing basic properties for the widget:
+   *  - #entity_type: The name of the entity the field is attached to.
+   *  - #bundle: The name of the field bundle the field is contained in.
+   *  - #field_name: The name of the field.
+   *  - #language: The language the field is being edited in.
+   *  - #field_parents: The 'parents' space for the field in the form. Most
+   *    widgets can simply overlook this property. This identifies the location
+   *    where the field values are placed within $form_state['values'], and is
+   *    used to access processing information for the field through the
+   *    field_form_get_state() and field_form_set_state() functions.
+   *  - #columns: A list of field storage columns of the field.
+   *  - #title: The sanitized element label for the field instance, ready for
+   *    output.
+   *  - #description: The sanitized element description for the field instance,
+   *    ready for output.
+   *  - #required: A Boolean indicating whether the element value is required;
+   *    for required multiple value fields, only the first widget's values are
+   *    required.
+   *  - #delta: The order of this item in the array of subelements; see
+   *    $delta above
+   */
+  public function form(&$widget, &$form, &$form_state, $langcode, $items, $delta, $element) {
+    // This widget applies only to type data identifier although it is attached to text
+    // field which is a general field type. An warning if this is applied to other text field.
+
+    if ($element['#field_name'] == 'data__identifier' && strtolower($element['#title']) == 'identifier') {
+      // In identifier field.
+
+      // Text field. In either cases this field must be disabled from user.
+      $field_name = $this->field['field_name'];
+      $field_table = $this->instance['settings']['chado_table'];
+      $linker_field = 'chado-' . $field_table . '__uniquename';
+
+      // When interface to set prefix:
+      // Notice for admin where they can alter the prefix use to formulate uniquename.
+      // tripal_set_message('Administrators, you can set prefix used in uniquename field in [link here].', TRIPAL_INFO, array('return_html' => FALSE));
+
+      // Dertermine if process is Create or Update. To test: check if chado_record_id
+      // were set to an id number.
+      if (isset($element['#entity']->chado_record_id) && $element['#entity']->chado_record_id > 0) {
+        // Update here.
+        
+        $unique_name = array_key_exists($delta, $items) ? $items[$delta]['value'] : '';
+        $desciption = '';
+        
+        // Feed to this field the uniquename for this stock.
+        $widget['value'] = array(
+          '#type' => 'value',
+          '#value' => array_key_exists($delta, $items) ? $items[$delta]['value'] : '',
+        );
+      }
+      else {
+        // Create.
+        
+        // Pull system variable for configured prefix.
+        $prefix = variable_get('trpfancy_field_identifier_prefix');
+        $unique_name = $prefix . ' + ID #';
+        $desciption = 'ID # will be set automatically on creation.';
+        
+        // Use this to flag process that user is creating a new record.
+        $form['trpfancy_fields_field_name'] = array(
+          '#type' => 'value',
+          '#value' => $field_name,
+        );
+        
+        $widget['table'] = array(
+          '#type' => 'value',
+          '#value' => $field_table,
+        );
+      
+        $id = uniqid();
+        // What actually gets saved.
+        $widget['value'] = array(
+          '#type' => 'value',
+          '#value' => $id,
+        ); 
+      }
+      
+      // The value presented to the user via load.
+      // If $items['delta']['value'] is set then we are updating and already have this
+      // information. As such, simply save it again.
+      
+      // What user sees.
+      $widget[$linker_field] = array(
+        '#type'   => 'textfield',
+        '#title'   => 'Uniquename',
+        '#value'    => $unique_name,
+        //'#disabled'  => TRUE,
+        '#description' => $desciption,
+      );
+    }
+    else {
+      // Text field but not identifier.
+      drupal_set_message('This option is available only to Identifier (text field).', 'error');
+      tripal_set_message('Administrators, please ensure that you are adding this autocomplete uniquename field only to Identifier field.', TRIPAL_INFO, array('return_html' => FALSE));
+    }
+  }
+
+  /**
+   * Performs validation of the widgetForm.
+   *
+   * Use this validate to ensure that form values are entered correctly.
+   * The 'value' key of this field must be set in the $form_state['values']
+   * array anytime data is entered by the user.  It may be the case that there
+   * are other fields for helping select a value. In the end those helper
+   * fields must be used to set the 'value' field.
+   */
+  public function validate($element, $form, &$form_state, $langcode, $delta) {
+  }
+
+  /**
+   * Performs extra commands when the entity form is submitted.
+   *
+   * Drupal typically does not provide a submit hook for fields.  The
+   * TripalField provides one to allow for behind-the-scenes actions to
+   * occur.   This function should never be used for updates, deletes or
+   * inserts for the Chado table associated with the field.  Rather, the
+   * storage backend should be allowed to handle inserts, updates deletes.
+   * However, it is permissible to perform inserts, updates or deletions within
+   * Chado using this function.  Those operations can be performed if needed but
+   * on other tables not directly associated with the field.
+   *
+   * An example is the chado.feature_synonym table.  The chado_linker__synonym
+   * field allows the user to provide a brand new synonynm and it must add it
+   * to the chado.synonym table prior to the record in the
+   * chado.feature_synonym table.  This insert occurs in the widgetFormSubmit
+   * function.
+   *
+   *  @param $entity_type
+   *    The type of $entity.
+   *  @param $entity
+   *    The entity for the operation.
+   *  @param $field
+   *    The field structure for the operation.
+   *  @param $instance
+   *    The instance structure for $field on $entity's bundle.
+   *  @param $langcode
+   *    The language associated with $items.
+   *  @param $items
+   *    $entity->{$field['field_name']}[$langcode], or an empty array if unset.
+   *  @param $form
+   *    The submitted form array.
+   *  @param $form_state.
+   *    The form state array.
+   */
+  public function submit($form, &$form_state, $entity_type, $entity, $langcode, $delta) {
+    // Alter the value of the unique name to the unique id generated.
+    // Once save, this temp uniquename will be used to query back the same record 
+    // to the final alteration of the uniquename to contain the primary key.
+    if(isset($form_state['values']['trpfancy_fields_field_name'])) {
+      // See callback function below.
+      $field_name = $this->instance['field_name'];
+      $field_table = $this->instance['settings']['chado_table'];
+      $linker_field = 'chado-' . $field_table . '__uniquename';
+    
+      $tmp_uniquename = $form_state['values'][$field_name]['und'][0]['value'];
+    
+      $prefix = variable_get('trpfancy_field_identifier_prefix');   
+      $form_state['values'][$field_name][$langcode][$delta][$linker_field] = $prefix . $tmp_uniquename;
+    }
+    
+    parent::submit($form, $form_state, $entity_type, $entity, $langcode, $delta);
+  }
+}
+
+  /**
+   * Function callback: 
+   * This function gets executed after submit() above and performs
+   * the final alteration to the uniquename.
+   */
+  function trpfancy_fields_entity_insert($entity, $type) {
+    // Apply this hook only to field of type Tripal Entity
+    // and the data array contains the data_identifier field.
+    if ($type == 'TripalEntity' && isset($entity->trpfancy_fields_field_name)) {
+      $f = $entity->trpfancy_fields_field_name; 
+      $arr = $entity->$f;
+      $data = $arr['und'][0];
+      
+      $tmp_uniquename = $data['value'];
+      $prefix = variable_get('trpfancy_field_identifier_prefix');
+    
+      // Find the primary key of the table this uniquename is attached to.
+      $pk = chado_query("SELECT column_name FROM information_schema.COLUMNS WHERE TABLE_NAME = :table",
+        array(':table' => $data['table']))
+        ->fetchField(); 
+    
+      $sql = sprintf("SELECT %s FROM {%s} WHERE uniquename = :uniquename LIMIT 1", $pk, $data['table']);
+      $id = chado_query($sql, array(':uniquename' => $prefix . $tmp_uniquename))
+        ->fetchField();
+    
+      if ($id) {
+        // New id.
+        $new_uniquename = $prefix . $id;
+    
+        chado_update_record($data['table'],
+          array('uniquename' => $prefix . $tmp_uniquename),
+          array('uniquename' => $new_uniquename)
+        );
+      }
+    }
+  }

--- a/includes/TripalFields/data__identifier/data__identifier_widget.inc
+++ b/includes/TripalFields/data__identifier/data__identifier_widget.inc
@@ -91,10 +91,10 @@ class data__identifier_widget extends ChadoFieldWidget {
       // were set to an id number.
       if (isset($element['#entity']->chado_record_id) && $element['#entity']->chado_record_id > 0) {
         // Update here.
-        
+
         $unique_name = array_key_exists($delta, $items) ? $items[$delta]['value'] : '';
         $desciption = '';
-        
+
         // Feed to this field the uniquename for this stock.
         $widget['value'] = array(
           '#type' => 'value',
@@ -103,35 +103,35 @@ class data__identifier_widget extends ChadoFieldWidget {
       }
       else {
         // Create.
-        
+
         // Pull system variable for configured prefix.
         $prefix = variable_get('trpfancy_field_identifier_prefix');
         $unique_name = $prefix . ' + ID #';
         $desciption = 'ID # will be set automatically on creation.';
-        
+
         // Use this to flag process that user is creating a new record.
         $form['trpfancy_fields_field_name'] = array(
           '#type' => 'value',
           '#value' => $field_name,
         );
-        
+
         $widget['table'] = array(
           '#type' => 'value',
           '#value' => $field_table,
         );
-      
+
         $id = uniqid();
         // What actually gets saved.
         $widget['value'] = array(
           '#type' => 'value',
           '#value' => $id,
-        ); 
+        );
       }
-      
+
       // The value presented to the user via load.
       // If $items['delta']['value'] is set then we are updating and already have this
       // information. As such, simply save it again.
-      
+
       // What user sees.
       $widget[$linker_field] = array(
         '#type'   => 'textfield',
@@ -197,26 +197,26 @@ class data__identifier_widget extends ChadoFieldWidget {
    */
   public function submit($form, &$form_state, $entity_type, $entity, $langcode, $delta) {
     // Alter the value of the unique name to the unique id generated.
-    // Once save, this temp uniquename will be used to query back the same record 
+    // Once save, this temp uniquename will be used to query back the same record
     // to the final alteration of the uniquename to contain the primary key.
     if(isset($form_state['values']['trpfancy_fields_field_name'])) {
       // See callback function below.
       $field_name = $this->instance['field_name'];
       $field_table = $this->instance['settings']['chado_table'];
       $linker_field = 'chado-' . $field_table . '__uniquename';
-    
+
       $tmp_uniquename = $form_state['values'][$field_name]['und'][0]['value'];
-    
-      $prefix = variable_get('trpfancy_field_identifier_prefix');   
+
+      $prefix = variable_get('trpfancy_field_identifier_prefix');
       $form_state['values'][$field_name][$langcode][$delta][$linker_field] = $prefix . $tmp_uniquename;
     }
-    
+
     parent::submit($form, $form_state, $entity_type, $entity, $langcode, $delta);
   }
 }
 
   /**
-   * Function callback: 
+   * Function callback:
    * This function gets executed after submit() above and performs
    * the final alteration to the uniquename.
    */
@@ -224,26 +224,26 @@ class data__identifier_widget extends ChadoFieldWidget {
     // Apply this hook only to field of type Tripal Entity
     // and the data array contains the data_identifier field.
     if ($type == 'TripalEntity' && isset($entity->trpfancy_fields_field_name)) {
-      $f = $entity->trpfancy_fields_field_name; 
+      $f = $entity->trpfancy_fields_field_name;
       $arr = $entity->$f;
       $data = $arr['und'][0];
-      
+
       $tmp_uniquename = $data['value'];
       $prefix = variable_get('trpfancy_field_identifier_prefix');
-    
+
       // Find the primary key of the table this uniquename is attached to.
       $pk = chado_query("SELECT column_name FROM information_schema.COLUMNS WHERE TABLE_NAME = :table",
         array(':table' => $data['table']))
-        ->fetchField(); 
-    
+        ->fetchField();
+
       $sql = sprintf("SELECT %s FROM {%s} WHERE uniquename = :uniquename LIMIT 1", $pk, $data['table']);
       $id = chado_query($sql, array(':uniquename' => $prefix . $tmp_uniquename))
         ->fetchField();
-    
+
       if ($id) {
         // New id.
         $new_uniquename = $prefix . $id;
-    
+
         chado_update_record($data['table'],
           array('uniquename' => $prefix . $tmp_uniquename),
           array('uniquename' => $new_uniquename)

--- a/includes/TripalFields/data__identifier/data__identifier_widget.inc
+++ b/includes/TripalFields/data__identifier/data__identifier_widget.inc
@@ -143,7 +143,7 @@ class data__identifier_widget extends ChadoFieldWidget {
         '#type'   => 'textfield',
         '#title'   => 'Uniquename',
         '#value'    => $unique_name,
-        //'#disabled'  => TRUE,
+        '#disabled'  => TRUE,
         '#description' => $desciption,
       );
     }

--- a/includes/TripalFields/data__identifier/data__identifier_widget.inc
+++ b/includes/TripalFields/data__identifier/data__identifier_widget.inc
@@ -89,25 +89,25 @@ class data__identifier_widget extends ChadoFieldWidget {
       $link = l('Update Prefix', 'admin/tripal/extension/trpfancy_fields/prefix');
       tripal_set_message('Administrators, you can set prefix used in uniquename field in ' . $link . '.', TRIPAL_INFO, array('return_html' => FALSE));
 
+      // Pull system variable for configured prefix.
+      $prefix = variable_get('trpfancy_field_identifier_prefix');
+
       // Dertermine if process is Create or Update. To test: check if chado_record_id
       // were set to an id number.
       if (isset($element['#entity']->chado_record_id) && $element['#entity']->chado_record_id > 0) {
         // Update here.
 
-        $unique_name = array_key_exists($delta, $items) ? $items[$delta]['value'] : '';
+        $unique_name = $prefix . $element['#entity']->chado_record_id;
         $desciption = '';
 
         // Feed to this field the uniquename for this stock.
         $widget['value'] = array(
           '#type' => 'value',
-          '#value' => array_key_exists($delta, $items) ? $items[$delta]['value'] : '',
+          '#value' => $unique_name,
         );
       }
       else {
         // Create.
-
-        // Pull system variable for configured prefix.
-        $prefix = variable_get('trpfancy_field_identifier_prefix');
 
         if (isset($prefix) && !empty($prefix)) {
           $unique_name = $prefix . ' + ID #';
@@ -149,7 +149,7 @@ class data__identifier_widget extends ChadoFieldWidget {
     }
     else {
       // Text field but not identifier.
-      drupal_set_message('This option is available only to Identifier (text field).', 'error');
+      drupal_set_message('This option is available only to Identifier (text field). Please restore field <em>' . $element['#title'] . '</em> to Text type.', 'error');
       tripal_set_message('Administrators, please ensure that you are adding this autocomplete uniquename field only to Identifier field.', TRIPAL_INFO, array('return_html' => FALSE));
     }
   }

--- a/trpfancy_fields.module
+++ b/trpfancy_fields.module
@@ -36,7 +36,7 @@ function trpfancy_fields_menu() {
   // Menu home.
   $items['admin/tripal/extension/trpfancyfields'] = array(
     'title' => 'Tripal Fancy Fields Configuration',
-    'description' => 'Configure Tripal Fancy Fields.',
+    'description' => 'Tripal Fancy Fields.',
     'access arguments' => array('administer tripal'),
   );
   

--- a/trpfancy_fields.module
+++ b/trpfancy_fields.module
@@ -33,16 +33,24 @@ function trpfancy_fields_add_field_terms() {
  * Implements hook_menu().
  */
 function trpfancy_fields_menu() {
+  // Menu home.
+  $items['admin/tripal/extension/trpfancyfields'] = array(
+    'title' => 'Tripal Fancy Fields Configuration',
+    'description' => 'Configure Tripal Fancy Fields.',
+    'access arguments' => array('administer tripal'),
+  );
+  
   // ADMISTRATIVE PAGE:
   // A page for changing prefix used to generate uniquename in Identifier field.
   // NOTE: this variable is used by data__identifier field.
-  $items['admin/tripal/extension/trpfancy_fields/prefix'] = array(
+  $items['admin/tripal/extension/trpfancyfields/prefix'] = array(
     'title'     => 'Configure Data Identifier Prefix',
     'description' => t('Provides interface for configuring prefix used to auto-generate uniquename/identifier.'),
     'page callback' => 'drupal_get_form',
     'page arguments' => array('trpfancy_fields_config'),
-    'access arguments' => array('access administration pages'),
+    'access arguments' => array('administer tripal'),
     'type' => MENU_NORMAL_ITEM,
+    'weight' => 1,
   );
 
   return $items;

--- a/trpfancy_fields.module
+++ b/trpfancy_fields.module
@@ -27,3 +27,52 @@ function trpfancy_fields_add_field_terms() {
     tripal_insert_cvterm($term);
   }
 }
+
+
+/**
+ * Implements hook_menu().
+ */
+function trpfancy_fields_menu() {
+  // ADMISTRATIVE PAGE:
+  // A page for changing prefix used to generate uniquename in Identifier field.
+  $items['admin/tripal/extension/trpfancy_fields/prefix'] = array(
+    'title'     => 'Configure Data Identifier Prefix',
+    'description' => 'Provides interface for configuring prefix used to auto-generate uniquename/identifier.',
+    'page callback' => 'drupal_get_form',
+    'page arguments' => array('trpfancy_fields_config'),
+    'access arguments' => array('access administration pages'),
+    'type' => MENU_NORMAL_ITEM,
+  );
+
+  return $items;
+}
+
+/**
+ * Function callback:
+ * Construct form interface to update prefix configuration.
+ */
+function trpfancy_fields_config($form, &$form_state) {
+  // System variable used to store prefix value:
+  // NOTE: this variable is used by data__identifier field.
+  $cur_prefix = variable_get('trpfancy_field_identifier_prefix');
+
+  $form['preview_prefix'] = array(
+    '#type' => 'markup',
+    '#markup' => 'Example (Prefix + ID#): <br />
+      <div style="font-family: courier, serif; font-size: 2em; margin: 5px 0 20px 0; border: 1px solid #CCCCCC; padding: 10px; display: inline-block;">'
+      . $cur_prefix . '<span style="color: #666666">' . mt_rand(7777, 9999) . '</span></div>',
+  );
+
+  $form['trpfancy_field_identifier_prefix'] = array(
+    '#type' => 'textfield',
+    '#title' => t('Prefix'),
+    '#description' => t('Prefix used to generate uniquename for Identifier field.'),
+    '#default_value' => $cur_prefix,
+    '#required' => TRUE,
+  );
+
+  // This will add a save button to this form, thus
+  // no hook_submit nor hook_validate is required.
+  return system_settings_form($form);
+}
+

--- a/trpfancy_fields.module
+++ b/trpfancy_fields.module
@@ -35,7 +35,7 @@ function trpfancy_fields_add_field_terms() {
 function trpfancy_fields_menu() {
   // Menu home.
   $items['admin/tripal/extension/trpfancyfields'] = array(
-    'title' => 'Tripal Fancy Fields Configuration',
+    'title' => 'Tripal Fancy Fields',
     'description' => 'Tripal Fancy Fields.',
     'access arguments' => array('administer tripal'),
   );

--- a/trpfancy_fields.module
+++ b/trpfancy_fields.module
@@ -5,6 +5,7 @@
 
 // Includes all non-class field functions.
 include('includes/trpfancy_fields.fields.inc');
+include('includes/TripalFields/data__identifier/data__identifier_widget.inc');
 
 /**
  * Add all terms needed for our fields

--- a/trpfancy_fields.module
+++ b/trpfancy_fields.module
@@ -35,9 +35,10 @@ function trpfancy_fields_add_field_terms() {
 function trpfancy_fields_menu() {
   // ADMISTRATIVE PAGE:
   // A page for changing prefix used to generate uniquename in Identifier field.
+  // NOTE: this variable is used by data__identifier field.
   $items['admin/tripal/extension/trpfancy_fields/prefix'] = array(
     'title'     => 'Configure Data Identifier Prefix',
-    'description' => 'Provides interface for configuring prefix used to auto-generate uniquename/identifier.',
+    'description' => t('Provides interface for configuring prefix used to auto-generate uniquename/identifier.'),
     'page callback' => 'drupal_get_form',
     'page arguments' => array('trpfancy_fields_config'),
     'access arguments' => array('access administration pages'),
@@ -46,6 +47,7 @@ function trpfancy_fields_menu() {
 
   return $items;
 }
+
 
 /**
  * Function callback:
@@ -56,6 +58,7 @@ function trpfancy_fields_config($form, &$form_state) {
   // NOTE: this variable is used by data__identifier field.
   $cur_prefix = variable_get('trpfancy_field_identifier_prefix');
 
+  // Show an example of the prefix in action.
   $form['preview_prefix'] = array(
     '#type' => 'markup',
     '#markup' => 'Example (Prefix + ID#): <br />
@@ -63,9 +66,10 @@ function trpfancy_fields_config($form, &$form_state) {
       . $cur_prefix . '<span style="color: #666666">' . mt_rand(7777, 9999) . '</span></div>',
   );
 
+  // Prefix field.
   $form['trpfancy_field_identifier_prefix'] = array(
-    '#type' => 'textfield',
-    '#title' => t('Prefix'),
+    '#type'    => 'textfield',
+    '#title'     => t('Prefix'),
     '#description' => t('Prefix used to generate uniquename for Identifier field.'),
     '#default_value' => $cur_prefix,
     '#required' => TRUE,
@@ -75,4 +79,3 @@ function trpfancy_fields_config($form, &$form_state) {
   // no hook_submit nor hook_validate is required.
   return system_settings_form($form);
 }
-


### PR DESCRIPTION
This PR will automate creation of value that will go in the uniquename field when adding record to a chado table (ie, stocks or features).
![Screen Shot 2019-04-04 at 10 13 27 AM (2)](https://user-images.githubusercontent.com/15472253/55571324-8ebe6f80-56c2-11e9-94a6-7b896ea74e18.png)

NOTE: this field has a global scope in that it applies to any field that has a type "TEXT":
![Screen Shot 2019-04-04 at 10 12 06 AM (2)](https://user-images.githubusercontent.com/15472253/55571419-b6153c80-56c2-11e9-967b-064b8c8d16ac.png)
When editing text field, additional option will become available as shown by the image above.
Setting the new option to another TEXT field other than "Identifier Field" will be instructed as shown by image below.
![Screen Shot 2019-04-04 at 10 07 37 AM (2)](https://user-images.githubusercontent.com/15472253/55571609-0f7d6b80-56c3-11e9-8f5b-dfb0cdbf4b9e.png)

TO TEST:
1. Enter desired prefix as shown by the image below:
![Screen Shot 2019-04-04 at 10 21 17 AM (2)](https://user-images.githubusercontent.com/15472253/55571816-861a6900-56c3-11e9-98a1-55f14cf88aef.png)
![Screen Shot 2019-04-04 at 10 43 11 AM (2)](https://user-images.githubusercontent.com/15472253/55573157-92ec8c00-56c6-11e9-9381-3ec1feda222a.png)

2. Update Tripal content and Edit "Identifier" widget and set the value to "Autocomplete uniquename"
![Screen Shot 2019-04-04 at 10 12 06 AM (2)](https://user-images.githubusercontent.com/15472253/55571969-d4c80300-56c3-11e9-9e02-e66eae9e6016.png)
3. Add record. The prefix entered will show in the "Uniquename* field" plus a ID# placeholder.
As indicated, the id number will be replaced by a numeric value (primary key id #).
![Screen Shot 2019-04-04 at 10 24 53 AM (2)](https://user-images.githubusercontent.com/15472253/55572023-f5905880-56c3-11e9-97c8-ab521e715800.png)





